### PR TITLE
Clean up routing

### DIFF
--- a/Sources/App/Models/ListTalksMessage.swift
+++ b/Sources/App/Models/ListTalksMessage.swift
@@ -11,13 +11,15 @@ struct ListTalksMessage: SlackMessage, JSONRepresentable {
     
     let text: String
     let attachments: [MessageAttachment] = []
-    let responseType: SlackMessageType = .inChannel
+    let responseType: SlackMessageType
     
     init(talks: [Talk]) {
         if talks.count == 0 {
             self.text = "No talks have been suggested.\nSuggest one with `/suggest_talk [talk idea]`"
+            self.responseType = .ephemeral
         } else {
             self.text = "Suggested talks:\n>>> - " + talks.map { $0.content }.joined(separator: "\n- ")
+            self.responseType = .inChannel
         }
     }
 }


### PR DESCRIPTION
Previously, I was passing `drop.client` to the controller for making HTTP requests out of the service. I refactored it to instead use `EngineClient.factory`. This allowed me to significantly clean up the routes.